### PR TITLE
Fixed an issue where the converter would generate duplicate key names in the "Entries" dictionary.

### DIFF
--- a/src/Converter.py
+++ b/src/Converter.py
@@ -34,7 +34,7 @@ class Converter:
                     'Action': 'EditData',
                     'Target': 'spacechase0.SpaceCore/TextureOverrides',
                     'Entries': {
-                        self.manifest['UniqueID'] + '_' + change['Target']: {
+                        self.manifest['UniqueID'] + '_' + change['Target'] + '/' + change['LogName'].replace(' ' , ''): {
                             'TargetTexture': change['Target'],
                             'TargetRect': {
                                 "X": 0,


### PR DESCRIPTION
Fixes #3 : This PR updates the key naming logic in the converter to include `LogName`, preventing duplicate keys in the `Entries` dictionary.